### PR TITLE
Fix blank admin panel

### DIFF
--- a/admin/src/components/BlocksInput/Blocks/Code.tsx
+++ b/admin/src/components/BlocksInput/Blocks/Code.tsx
@@ -14,6 +14,10 @@ import { baseHandleConvert } from '../utils/conversions';
 import { pressEnterTwiceToExit } from '../utils/enterKey';
 import { CustomElement, CustomText, type Block } from '../utils/types';
 
+if (typeof window !== 'undefined') {
+  (window as any).Prism = Prism;
+}
+
 import 'prismjs/themes/prism-solarizedlight.css';
 import 'prismjs/components/prism-asmatmel';
 import 'prismjs/components/prism-bash';

--- a/admin/src/components/Input.tsx
+++ b/admin/src/components/Input.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { BlocksEditor } from './BlocksInput/BlocksEditor';
-import { Field, Flex } from '@strapi/design-system';
-
+import { DesignSystemProvider, lightTheme, Field, Flex } from '@strapi/design-system';
 
 interface InputProps {
   attribute: {
@@ -44,9 +43,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     try {
       if (props.value) {
         const parsed = typeof props.value === 'string' ? JSON.parse(props.value) : props.value;
-        return Array.isArray(parsed)
-          ? parsed
-          : [{ type: 'paragraph', children: [{ text: '' }] }];
+        return Array.isArray(parsed) ? parsed : [{ type: 'paragraph', children: [{ text: '' }] }];
       }
     } catch (e) {
       console.error('Failed to parse value:', e);
@@ -69,35 +66,37 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   };
 
   return (
-    <Field.Root
-      id={props.name}
-      name={props.name}
-      required={props.required}
-      error={props.error}
-      hint={props?.hint}
-    >
-      <Flex direction="column" alignItems="stretch" gap={1}>
-        <Field.Label>{props.label}</Field.Label>
-        <BlocksEditor
-          ref={ref as any}
-          name={props.name}
-          error={props.error}
-          value={editorValue}
-          ariaLabelId={props.name}
-          disabled={props.disabled}
-          pluginOptions={props.attribute.options}
-          onChange={(eventOrPath, value) => {
-            if (typeof eventOrPath === 'string') {
-              handleChange(eventOrPath, value);
-            } else {
-              handleChange(props.name, eventOrPath.target.value);
-            }
-          }}
-        />
-        <Field.Hint />
-        <Field.Error />
-      </Flex>
-    </Field.Root>
+    <DesignSystemProvider theme={lightTheme}>
+      <Field.Root
+        id={props.name}
+        name={props.name}
+        required={props.required}
+        error={props.error}
+        hint={props?.hint}
+      >
+        <Flex direction="column" alignItems="stretch" gap={1}>
+          <Field.Label>{props.label}</Field.Label>
+          <BlocksEditor
+            ref={ref as any}
+            name={props.name}
+            error={props.error}
+            value={editorValue}
+            ariaLabelId={props.name}
+            disabled={props.disabled}
+            pluginOptions={props.attribute.options}
+            onChange={(eventOrPath, value) => {
+              if (typeof eventOrPath === 'string') {
+                handleChange(eventOrPath, value);
+              } else {
+                handleChange(props.name, eventOrPath.target.value);
+              }
+            }}
+          />
+          <Field.Hint />
+          <Field.Error />
+        </Flex>
+      </Field.Root>
+    </DesignSystemProvider>
   );
 });
 

--- a/package.json
+++ b/package.json
@@ -43,12 +43,14 @@
     "@types/prismjs": "1.26.5",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "esbuild": "^0.27.0",
     "prettier": "^3.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.0",
     "styled-components": "^6.1.17",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "zod": "^4.1.13"
   },
   "peerDependencies": {
     "@strapi/design-system": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "zod": "^4.1.13"
   },
   "peerDependencies": {
-    "@strapi/design-system": "^2.0.0",
+    "@strapi/design-system": "^2.0.1",
     "@strapi/icons": "^2.0.0",
     "@strapi/strapi": "^5.12.5",
     "prismjs": "1.30.0",


### PR DESCRIPTION
Certainly on Strapi 5.31.0, and probably somewhere between 5.12 and 5.31, `npm i strapi-plugin-rich-text-blocks-extended` in a project would require the project to also install esbuild and zod. Worse, it would also cause the admin panel (really the entire Strapi interface on localhost) to display a blank page. Developer tools would show `Uncaught ReferenceError: Prism is not defined` 
The first commit of this PR fixes both.
_Rich Text Blocks (Extended)_ now shows up in the list of Custom fields, and can be added as a field in the Content-Type Builder.
However, my attempts to use a type with such an added field in the Content Manager, resulted in an error citing _Tooltip must be used within TooltipProvider_
The second commit fixes that.

If you are willing to replace prismjs with highlight.js, that works on my forked main branch. That avoids all of the issues that many experienced. It also does a beautiful job at language-specific syntax highlighting in the admin panel. Let me know, and I will update this PR.